### PR TITLE
EventBus failure handling

### DIFF
--- a/Regalo.Core.Tests.Unit/EventBusTests.cs
+++ b/Regalo.Core.Tests.Unit/EventBusTests.cs
@@ -43,7 +43,9 @@ namespace Regalo.Core.Tests.Unit
                 typeof(IEventHandler<object>),
                 typeof(IEventHandler<SimpleEventBase>),
                 typeof(IEventHandler<SimpleEvent>),
-                typeof(IEventHandler<EventHandlingSucceededEvent<SimpleEvent>>),
+                typeof(IEventHandler<IEventHandlingSucceededEvent<object>>),
+                typeof(IEventHandler<IEventHandlingSucceededEvent<SimpleEventBase>>),
+                typeof(IEventHandler<IEventHandlingSucceededEvent<SimpleEvent>>)
             };
 
             var result = new List<Type>();
@@ -111,7 +113,7 @@ namespace Regalo.Core.Tests.Unit
                 new[]
                 {
                     typeof(SimpleEvent),
-                    typeof(EventHandlingFailedEvent<SimpleEvent>)
+                    typeof(IEventHandlingFailedEvent<SimpleEvent>)
                 },
                 failingEventHandler.TargetsCalled);
         }
@@ -176,7 +178,7 @@ namespace Regalo.Core.Tests.Unit
         }
     }
 
-    public class FailingEventHandler : IEventHandler<SimpleEvent>, IEventHandler<EventHandlingFailedEvent<SimpleEvent>>
+    public class FailingEventHandler : IEventHandler<SimpleEvent>, IEventHandler<IEventHandlingFailedEvent<SimpleEvent>>
     {
         public readonly IList<Type> TargetsCalled = new List<Type>();
         public readonly IList<Type> MessageTypes = new List<Type>();
@@ -189,9 +191,9 @@ namespace Regalo.Core.Tests.Unit
             throw new Exception("Deliberate failure.");
         }
 
-        public void Handle(EventHandlingFailedEvent<SimpleEvent> evt)
+        public void Handle(IEventHandlingFailedEvent<SimpleEvent> evt)
         {
-            TargetsCalled.Add(typeof(EventHandlingFailedEvent<SimpleEvent>));
+            TargetsCalled.Add(typeof(IEventHandlingFailedEvent<SimpleEvent>));
             MessageTypes.Add(evt.GetType());
         }
     }

--- a/Regalo.Core/Conventions.cs
+++ b/Regalo.Core/Conventions.cs
@@ -7,10 +7,12 @@ namespace Regalo.Core
         private static bool _aggregatesMustImplementApplyMethods = false;
         private static string _aggregateIdPropertyName = "AggregateId";
         private static Func<Type, Type> _findAggregateTypeForEventType = null;
+        private static Func<object, Exception, bool> _retryableEventHandlingExceptionFilter = null;
 
         public static string AggregateIdPropertyName { get { return _aggregateIdPropertyName; } }
         public static bool AggregatesMustImplementApplyMethods { get { return _aggregatesMustImplementApplyMethods; } }
         public static Func<Type, Type> FindAggregateTypeForEventType { get { return _findAggregateTypeForEventType; } }
+        public static Func<object, Exception, bool> RetryableEventPublishingExceptionFilter { get { return _retryableEventHandlingExceptionFilter; } }
 
         public static void SetAggregateIdPropertyName(string value)
         {
@@ -25,6 +27,11 @@ namespace Regalo.Core
         public static void SetFindAggregateTypeForEventType(Func<Type, Type> findAggregateTypeForEventType)
         {
             _findAggregateTypeForEventType = findAggregateTypeForEventType;
+        }
+
+        public static void SetRetryableEventHandlingExceptionFilter(Func<object, Exception, bool> retryableEventHandlingExceptionFilter)
+        {
+            _retryableEventHandlingExceptionFilter = retryableEventHandlingExceptionFilter;
         }
     }
 }

--- a/Regalo.Core/EventBus.cs
+++ b/Regalo.Core/EventBus.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace Regalo.Core
 {
@@ -28,7 +26,7 @@ namespace Regalo.Core
             {
                 if (eventType != typeof(object))
                 {
-                    var failedEvent = MakeFailureEvent(evt, e);
+                    var failedEvent = EventHandlingFailedEvent.Create(evt, e);
                     _logger.Error(this, e, "Failed to handle {0}, publishing {1}...", evt, failedEvent);
                     HandleMessage(failedEvent, typeof(IEventHandler<>));
                 }
@@ -41,7 +39,7 @@ namespace Regalo.Core
 
             if (eventType != typeof(object))
             {
-                var succeededEvent = MakeSuccessEvent(evt);
+                var succeededEvent = EventHandlingSucceededEvent.Create(evt);
                 _logger.Debug(this, "Handled {0}, publishing {1}...", evt, succeededEvent);
                 HandleMessage(succeededEvent, typeof(IEventHandler<>));
             }
@@ -57,25 +55,6 @@ namespace Regalo.Core
             {
                 Publish(evt);
             }
-        }
-
-        private static object MakeSuccessEvent(object evt)
-        {
-            return WrapEvent(evt, typeof(EventHandlingSucceededEvent<>));
-        }
-
-        private static object MakeFailureEvent(object evt, Exception e)
-        {
-            return WrapEvent(evt, typeof(EventHandlingFailedEvent<>), e);
-        }
-
-        private static object WrapEvent(object evt, Type wrapperEventOpenType, params object[] additionalArguments)
-        {
-            var eventType = evt.GetType();
-            var wrapperEventTypeClosedType = wrapperEventOpenType.MakeGenericType(eventType);
-            var arguments = new[] { evt }.Concat(additionalArguments).ToArray();
-            var wrapperEvent = Activator.CreateInstance(wrapperEventTypeClosedType, arguments);
-            return wrapperEvent;
         }
     }
 }

--- a/Regalo.Core/EventBus.cs
+++ b/Regalo.Core/EventBus.cs
@@ -24,6 +24,12 @@ namespace Regalo.Core
             }
             catch (Exception e)
             {
+                if (IsRetryableException(evt, e))
+                {
+                    _logger.Error(this, e, "Failed to handle {0}, allowing retryable exception to propagate...");
+                    throw;
+                }
+
                 if (eventType != typeof(object))
                 {
                     var failedEvent = EventHandlingFailedEvent.Create(evt, e);
@@ -55,6 +61,12 @@ namespace Regalo.Core
             {
                 Publish(evt);
             }
+        }
+
+        private static bool IsRetryableException(object evt, Exception exception)
+        {
+            var filter = Conventions.RetryableEventPublishingExceptionFilter;
+            return filter != null && filter(evt, exception);
         }
     }
 }

--- a/Regalo.Core/EventBus.cs
+++ b/Regalo.Core/EventBus.cs
@@ -36,6 +36,7 @@ namespace Regalo.Core
                 {
                     _logger.Error(this, e, "Failed to handle {0} but NOT publishing EventHandlingFailedEvent<object>...", evt);
                 }
+                return;
             }
 
             if (eventType != typeof(object))

--- a/Regalo.Core/EventHandlingFailedEvent.cs
+++ b/Regalo.Core/EventHandlingFailedEvent.cs
@@ -2,15 +2,29 @@
 
 namespace Regalo.Core
 {
-    public class EventHandlingFailedEvent<TEvent> : EventHandlingResultEvent
+    public static class EventHandlingFailedEvent
     {
-        public TEvent    Evt       { get; private set; }
-        public Exception Exception { get; private set; }
-
-        public EventHandlingFailedEvent(TEvent evt, Exception exception)
+        public static IEventHandlingFailedEvent<TEvent> Create<TEvent>(TEvent evt, Exception exception)
         {
-            Evt       = evt;
-            Exception = exception;
+            return (IEventHandlingFailedEvent<TEvent>)WrapEvent(evt, exception);
+        }
+
+        private static object WrapEvent(object evt, Exception exception)
+        {
+            var wrapperType = typeof(EventHandlingFailedEventImpl<>).MakeGenericType(evt.GetType());
+            return Activator.CreateInstance(wrapperType, evt, exception);
+        }
+
+        private class EventHandlingFailedEventImpl<TEvent> : EventHandlingResultEvent, IEventHandlingFailedEvent<TEvent>
+        {
+            public TEvent Evt { get; private set; }
+            public Exception Exception { get; private set; }
+
+            public EventHandlingFailedEventImpl(TEvent evt, Exception exception)
+            {
+                Evt = evt;
+                Exception = exception;
+            }
         }
     }
 }

--- a/Regalo.Core/EventHandlingSucceededEvent.cs
+++ b/Regalo.Core/EventHandlingSucceededEvent.cs
@@ -1,12 +1,28 @@
-﻿namespace Regalo.Core
-{
-    public class EventHandlingSucceededEvent<TEvent> : EventHandlingResultEvent
-    {
-        public TEvent Evt { get; private set; }
+﻿using System;
 
-        public EventHandlingSucceededEvent(TEvent evt)
+namespace Regalo.Core
+{
+    public static class EventHandlingSucceededEvent
+    {
+        public static IEventHandlingSucceededEvent<TEvent> Create<TEvent>(TEvent evt)
         {
-            Evt = evt;
+            return (IEventHandlingSucceededEvent<TEvent>)WrapEvent(evt);
+        }
+
+        private static object WrapEvent(object evt)
+        {
+            var wrapperType = typeof(EventHandlingSucceededEventImpl<>).MakeGenericType(evt.GetType());
+            return Activator.CreateInstance(wrapperType, evt);
+        }
+
+        private class EventHandlingSucceededEventImpl<TEvent> : EventHandlingResultEvent, IEventHandlingSucceededEvent<TEvent>
+        {
+            public TEvent Evt { get; private set; }
+
+            public EventHandlingSucceededEventImpl(TEvent evt)
+            {
+                Evt = evt;
+            }
         }
     }
 }

--- a/Regalo.Core/IEventHandlingFailedEvent.cs
+++ b/Regalo.Core/IEventHandlingFailedEvent.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Regalo.Core
+{
+    public interface IEventHandlingFailedEvent<out TEvent>
+    {
+        TEvent Evt { get; }
+        Exception Exception { get; }
+    }
+}

--- a/Regalo.Core/IEventHandlingSucceededEvent.cs
+++ b/Regalo.Core/IEventHandlingSucceededEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Regalo.Core
+{
+    public interface IEventHandlingSucceededEvent<out TEvent>
+    {
+        TEvent Evt { get; }
+    }
+}

--- a/Regalo.Core/Regalo.Core.csproj
+++ b/Regalo.Core/Regalo.Core.csproj
@@ -64,6 +64,8 @@
     <Compile Include="IdNotSetException.cs" />
     <Compile Include="IEventBus.cs" />
     <Compile Include="IEventHandler.cs" />
+    <Compile Include="IEventHandlingFailedEvent.cs" />
+    <Compile Include="IEventHandlingSucceededEvent.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="IMessageHandlerContext.cs" />
     <Compile Include="IRepository.cs" />


### PR DESCRIPTION
- Fixed an issue where for failed handling, both an `EventHandlingFailedEvent<T>` and a `EventHandlingSucceededEvent<T>` were published.
- Changes to allow dispatching of `EventHandlingFailedEvent<T>` and `EventHandlingSucceededEvent<T>` to all handlers (i.e. for `T` and its inheritance chain).
  This is a **breaking change**: handlers should now be defined for interfaces `IEventHandlingSucceededEvent<T>` and `IEventHandlingFailedEvent<T>`, and the concrete types are no longer publicly creatable (but can be created in tests via `EventHandlingSucceededEvent.Create()` and `EventHandlingFailedEvent.Create()`).
- Added `Conventions.RetryableEventHandlingExceptionFilter`, a filter function that allows some failures during event handling to be designated as _retryable_. These exceptions aren't dispatched as `IEventHandlingFailedEvent<T>` events, but are instead alowed to "bubble up".
